### PR TITLE
Fix ranger.unify for probability forests

### DIFF
--- a/R/unify_ranger.R
+++ b/R/unify_ranger.R
@@ -42,7 +42,7 @@ ranger.unify <- function(rf_model, data) {
   x <- lapply(1:n, function(tree) {
     tree_data <- data.table::as.data.table(ranger::treeInfo(rf_model, tree = tree))
     # Fix for probability forests
-    if (rf$treetype == "Probability estimation") {
+    if (rf_model$treetype == "Probability estimation") {
       data.table::setnames(tree_data, "pred.1", "prediction")
     }
     tree_data[, c("nodeID",  "leftChild", "rightChild", "splitvarName", "splitval", "prediction")]

--- a/R/unify_ranger.R
+++ b/R/unify_ranger.R
@@ -43,7 +43,7 @@ ranger.unify <- function(rf_model, data) {
     tree_data <- data.table::as.data.table(ranger::treeInfo(rf_model, tree = tree))
     # Fix for probability forests
     if (rf$treetype == "Probability estimation") {
-      setnames(tree_data, "pred.1", "prediction")
+      data.table::setnames(tree_data, "pred.1", "prediction")
     }
     tree_data[, c("nodeID",  "leftChild", "rightChild", "splitvarName", "splitval", "prediction")]
   })

--- a/R/unify_ranger.R
+++ b/R/unify_ranger.R
@@ -41,6 +41,10 @@ ranger.unify <- function(rf_model, data) {
   n <- rf_model$num.trees
   x <- lapply(1:n, function(tree) {
     tree_data <- data.table::as.data.table(ranger::treeInfo(rf_model, tree = tree))
+    # Fix for probability forests
+    if (rf$treetype == "Probability estimation") {
+      setnames(tree_data, "pred.1", "prediction")
+    }
     tree_data[, c("nodeID",  "leftChild", "rightChild", "splitvarName", "splitval", "prediction")]
   })
   return(ranger_unify.common(x = x, n = n, data = data, feature_names = rf_model$forest$independent.variable.names))


### PR DESCRIPTION
This is a minor fix to allow ranger.unify() to work correctly when probability = TRUE in a ranger::ranger() model, i.e. a probability forest.

This example code will now work correctly:

=======
data = fifa20$data[, 1:8]
data$target_high = as.integer(fifa20$target > median(fifa20$target))
rf_model = ranger::ranger(target_high ~ ., data = data, num.trees = 10L, probability = TRUE)
unified = unify(rf_model, data)
treeshap1 = treeshap(unified, data[1:100, ], verbose = 0)
plot_feature_importance(treeshap1, max_vars = 6)
=======